### PR TITLE
Fix incorrect Internationalization import usage in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ npm install @aboutbits/internationalization
 Second, you can setup the tool with all supported languages and the fallback language and then detect the given browser language.
 
 ```js
-import { Internationalization } from '@aboutbits/internationalization'
+import Internationalization from '@aboutbits/internationalization'
 
 let supportedLanguages = ['en', 'de', 'it']
 let fallbackLanguage = 'en'


### PR DESCRIPTION
### Description
This PR fixes incorrect documentation regarding the import of `Internationalization` from `@aboutbits/internationalization`.

The docs previously suggested a named import:

```tsx
import { Internationalization } from '@aboutbits/internationalization'
```

However, the package actually exposes `Internationalization` as a default export, so the correct usage is:

```tsx
import Internationalization from '@aboutbits/internationalization'
```

#### Why is this change needed?

The previous documentation is misleading and results in a TypeScript error (`TS2614`).

### Tests
N/A (only README file update 🙂)